### PR TITLE
Update dockerfile to build the image using multistage to reduce size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,20 @@
-# Start from a Debian image with the latest version of Go installed
+# We are going to containerize this "service" using multi stage docker
+
+# Build stage
+# Start from a Alpine Debian image with the latest version of Go installed
 # and a workspace (GOPATH) configured at /go.
-FROM golang:alpine
+FROM golang:1.9-alpine
+WORKDIR /go/src/outyet
+COPY outyet.go .
+RUN go get -d ./... && go build -o outyet .
 
-# Copy the local package files to the container's workspace.
-ADD /outyet.go /go/src/outyet/
-
-# Build the outyet command inside the container.
-# (You may fetch or manage dependencies here,
-# either manually or with a tool like "godep".)
-RUN go install outyet
-
-# Run the outyet command by default when the container starts.
-ENTRYPOINT /go/bin/outyet
+# Final Stage
+FROM alpine:3.7
+RUN apk --no-cache add ca-certificates
+WORKDIR /root/
+COPY --from=0 /go/src/outyet .
 
 # Document that the service listens on port 8080.
 EXPOSE 8080
+# Run the outyet command by default when the container starts.
+ENTRYPOINT ./outyet


### PR DESCRIPTION
The changes made are:
- Use concrete version of the images **golang:1.9-alpine** instead of **golang;alpine** which avoids problems if a new update of the alpine version breaks the build process
- Add multistage to reduce the size of the final image from **385MB** to **13MB**